### PR TITLE
Fix command not found error

### DIFF
--- a/zsh-interactive-cd.plugin.zsh
+++ b/zsh-interactive-cd.plugin.zsh
@@ -69,7 +69,7 @@ __zic_fzf_bindings() {
   autoload is-at-least
   fzf=$(__zic_fzf_prog)
 
-  if $(is-at-least '0.21.0' $(${fzf} --version)); then
+  if $(is-at-least '0.21.0' $(${=fzf} --version)); then
     echo 'shift-tab:up,tab:down,bspace:backward-delete-char/eof'
   else
     echo 'shift-tab:up,tab:down'


### PR DESCRIPTION
Hey 👋

I upgraded recently and noticed i was getting the following error:

```
__zic_fzf_bindings:4: command not found: fzf-tmux -d50%
```

This would show when triggering completion (`cd <TAB>`)

The command would still actually work though... (I would see the tmux pane with the results)

I traced this back to the changes made [here](https://github.com/changyuheng/zsh-interactive-cd/pull/13), in particular [this](https://github.com/changyuheng/zsh-interactive-cd/commit/69b8f7c3a59c39059daaee55aac43fc2d172e625#diff-28b32220e254de8e1db06e121b14a061761b5c6ebb31fa102adb4d802eadccefR72) change. Looks to be some kind of expansion issue.

cc @jrwrigh 