### PR TITLE
Cleaned up and added option to match without case sensitivity

### DIFF
--- a/zsh-interactive-cd.plugin.zsh
+++ b/zsh-interactive-cd.plugin.zsh
@@ -66,8 +66,14 @@ __zic_matched_subdir_list() {
         if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
           continue
         fi
-        if [[ "$line" == "$seg"* ]]; then
-          echo "$line"
+        if [ "$zic_case_insensitive" = "true" ]; then
+          if [[ "$line:u" == "$seg:u"* ]]; then
+            echo "$line"
+          fi
+        else
+          if [[ "$line" == "$seg"* ]]; then
+            echo "$line"
+          fi
         fi
       done
     )
@@ -80,8 +86,14 @@ __zic_matched_subdir_list() {
         if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
           continue
         fi
-        if [[ "$line" == *"$seg"* ]]; then
-          echo "$line"
+        if [ "$zic_case_insensitive" = "true" ]; then
+          if [[ "$line:u" == *"$seg:u"* ]]; then
+            echo "$line"
+          fi
+        else
+          if [[ "$line" == *"$seg"* ]]; then
+            echo "$line"
+          fi
         fi
       done
     fi


### PR DESCRIPTION
1. I unpacked a lot of the `find | while` variables, moved repeated code to separate functions and fixed the formatting.
2. Added case insensitive matching (#1), using `$var:u` syntax. It can be enabled by setting `$zic_case_insensitive` to `true`.

Tested on `zsh 5.8 (x86_64-ubuntu-linux-gnu)`