### PR TITLE
added option to toggle case sensitivity

### DIFF
--- a/zsh-interactive-cd.plugin.zsh
+++ b/zsh-interactive-cd.plugin.zsh
@@ -43,8 +43,14 @@ __zic_matched_subdir_list() {
         if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
           continue
         fi
-        if [[ "$line" == "$seg"* ]]; then
-          echo "$line"
+        if [ "$zic_case_insensitive" = "true" ]; then
+          if [[ "$line:u" == "$seg:u"* ]]; then
+            echo "$line"
+          fi
+        else
+          if [[ "$line" == "$seg"* ]]; then
+            echo "$line"
+          fi
         fi
       done
     )
@@ -57,8 +63,14 @@ __zic_matched_subdir_list() {
         if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
           continue
         fi
-        if [[ "$line" == *"$seg"* ]]; then
-          echo "$line"
+        if [ "$zic_case_insensitive" = "true" ]; then
+          if [[ "$line:u" == *"$seg:u"* ]]; then
+            echo "$line"
+          fi
+        else
+          if [[ "$line" == *"$seg"* ]]; then
+            echo "$line"
+          fi
         fi
       done
     fi


### PR DESCRIPTION
Added case insensitive matching (#1), using `$var:u` syntax. It can be enabled by setting `$zic_case_insensitive` to true.