### PR TITLE
Add Fig as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 
 2. Source `zsh-interactive-cd.plugin.zsh` in `.zshrc`.
 
+#### Fig
+
+Install `zsh-interactive-cd` with [Fig](https://fig.io) in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-interactive-cd_changyuheng" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
+
 ## Usage
 
 Press tab for completion as usual, it'll launch fzf automatically. Check fzf’s [readme](https://github.com/junegunn/fzf#search-syntax) for more search syntax usage.


### PR DESCRIPTION
We recently listed on `zsh-interactive-cd` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!